### PR TITLE
requires libz to build (Ubuntu 18.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ autoreconf -i
 make
 sudo make install
 cd ..
-sudo apt-get install apache2 apache2-dev
+sudo apt-get install apache2 apache2-dev libz-dev
 git clone https://github.com/AnthonyDeroche/mod_authnz_jwt
 cd mod_authnz_jwt
 autoreconf -ivf


### PR DESCRIPTION
Without this dpeendency the build fails

    checking for Z... no
    configure: error: Package requirements (zlib) were not met:
    No package 'zlib' found
