### PR TITLE
Add config option to use a custom token name

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,12 @@ With Cookie:
 * **Possibles values**: JSON, Cookie
 * **Mandatory**: no
 
+##### AuthJWTTokenName
+* **Description**: Token name to use when using JSON delivery
+* **Context**: server config, directory
+* **Default**: token
+* **Mandatory**: no
+
 ##### AuthJWTCookieName
 * **Description**: Cookie name to use when using cookie delivery
 * **Context**: server config, directory

--- a/tests/apache_jwt.conf
+++ b/tests/apache_jwt.conf
@@ -104,6 +104,10 @@
     </LocationMatch>
 
     #special cases
+    <LocationMatch "token_custom_name">
+        AuthJWTTokenName CustomToken
+    </LocationMatch>
+
     <LocationMatch "cookie_custom_name">
         AuthJWTCookieName CustomCookie
     </LocationMatch>

--- a/tests/debian_tests.sh
+++ b/tests/debian_tests.sh
@@ -5,13 +5,16 @@ sudo cp jwt.htpasswd /var/www/jwt.htpasswd
 sudo mkdir -p /var/www/testjwt/
 sudo touch /var/www/testjwt/index.html
 
-mkdir -p /opt/mod_jwt_tests
+sudo mkdir -p /opt/mod_jwt_tests
 
 sudo openssl ecparam -name secp256k1 -genkey -noout -out /opt/mod_jwt_tests/ec-priv.pem
 sudo openssl ec -in /opt/mod_jwt_tests/ec-priv.pem -pubout -out /opt/mod_jwt_tests/ec-pub.pem
 
 sudo openssl genpkey -algorithm RSA -out /opt/mod_jwt_tests/rsa-priv.pem -pkeyopt rsa_keygen_bits:4096
 sudo openssl rsa -pubout -in /opt/mod_jwt_tests/rsa-priv.pem -out /opt/mod_jwt_tests/rsa-pub.pem
+
+sudo chmod 644 /opt/mod_jwt_tests/*.pem
+
 
 if ! sudo a2query -m rewrite > /dev/null; then
 	sudo a2enmod rewrite

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -31,6 +31,20 @@ class TestLogin(TestJWT):
         self.assertToken(received_object["token"], public_key, alg)
 
     @TestJWT.with_all_algorithms(algorithms=("HS256", "RS256", "ES256"))
+    def test_login_should_success_with_custom_token_name(self, alg, public_key, private_key, secured_url, login_url):
+        code, content, headers, cookies = self.http_post(login_url + "/token_custom_name", {self.USERNAME_FIELD:self.USERNAME, self.PASSWORD_FIELD:self.PASSWORD})
+
+        # we expect return code 200, JSON content type
+        self.assertEqual(code, 200)
+        self.assertEqual(headers.get("Content-Type"), "application/json")
+
+        # we check if the JSON object is correct and token is valid
+        received_object = json.loads(content)
+        self.assertTrue("CustomToken" in received_object)
+
+        self.assertToken(received_object["CustomToken"], public_key, alg)
+
+    @TestJWT.with_all_algorithms(algorithms=("HS256", "RS256", "ES256"))
     def test_login_with_bad_credentials_should_fail(self, alg, public_key, private_key, secured_url, login_url):
         code, content, headers, cookies = self.http_post(login_url, {self.USERNAME_FIELD:self.USERNAME, self.PASSWORD_FIELD:"azerty"})
         self.assertEqual(code, 401)


### PR DESCRIPTION
Added the "AuthJWTTokenName" config option to allow users to change the name of the cookie returned via JSON delivery (similarly to how you can change the cookie name with the "AuthJWTCookieName" option).