### PR TITLE
Updates AuthJWTExpDelay to allow restrictions to specific users

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,13 @@ With Cookie:
 * **Mandatory**: no
 
 ##### AuthJWTExpDelay 
-* **Description**: The time delay in seconds after which delivered tokens are considered invalid
+* **Description**: The time delay in seconds after which delivered tokens are considered invalid. Can be restricted to one or more users by providing a list of names.
 * **Context**: server config, directory
 * **Default**: 1800
+* **Examples**:
+   * AuthJWTExpDelay 3600
+   * AuthJWTExpDelay user1 7200
+   * AuthJWTExpDelay user1 user2 1800
 * **Mandatory**: no
 
 ##### AuthJWTNbfDelay 

--- a/mod_authnz_jwt.c
+++ b/mod_authnz_jwt.c
@@ -531,21 +531,23 @@ static const int get_config_exp_delay(request_rec *r, const char *username){
 			return *value;
 		}
 	}
-	else if (sconf->user_exp_delay != NULL) {
+
+	if (sconf->user_exp_delay != NULL) {
 		value = apr_hash_get(sconf->user_exp_delay, username, APR_HASH_KEY_STRING);
 		if (value) {
 			return *value;
 		}
 	}
-	else if (dconf->exp_delay_set) {
+
+	if (dconf->exp_delay_set) {
 		return dconf->exp_delay;
 	}
-	else if (sconf->exp_delay_set) {
+
+	if (sconf->exp_delay_set) {
 		return sconf->exp_delay;
 	}
-	else {
-		return DEFAULT_EXP_DELAY;
-	}
+
+	return DEFAULT_EXP_DELAY;
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  REGISTER HOOKS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  */

--- a/tests/apache_jwt.conf
+++ b/tests/apache_jwt.conf
@@ -111,4 +111,8 @@
     <LocationMatch "cookie_custom_attr">
         AuthJWTCookieAttr path=/secure;CustomAttr
     </LocationMatch>
+
+    <LocationMatch "user_exp_delay">
+        AuthJWTExpDelay test 7200
+    </LocationMatch>
 </VirtualHost>

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -19,6 +19,7 @@ class TestJWT(unittest.TestCase):
     USERNAME_FIELD = "user"
     PASSWORD_FIELD = "password"
     JWT_EXPDELAY = 1800
+    JWT_USER_EXPDELAY = 7200
     JWT_NBF_DELAY = 0
     JWT_ISS = "testjwt.local"
     JWT_AUD = "tests"

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -89,3 +89,15 @@ class TestLogin(TestJWT):
             self.assertTrue(c.has_nonstandard_attr('CustomAttr'))
 
             self.assertToken(c.value, public_key, alg)
+
+    @TestJWT.with_all_algorithms(algorithms=("HS256",))
+    def test_login_should_success_with_user_exp_delay(self, alg, public_key, private_key, secured_url, login_url):
+        code, content, headers, cookies = self.http_post(login_url + "/user_exp_delay", {self.USERNAME_FIELD:self.USERNAME, self.PASSWORD_FIELD:self.PASSWORD})
+
+        self.assertEqual(code, 200)
+
+        received_object = json.loads(content)
+        self.assertTrue("token" in received_object)
+
+        jwt_fields = self.decode_jwt(received_object["token"], public_key, alg)
+        self.assertEqual(int(jwt_fields["exp"])-int(jwt_fields["iat"]), self.JWT_USER_EXPDELAY)


### PR DESCRIPTION
This change updates the AuthJWTExpDelay to allow an optional list of users before the delay, which will only apply that delay to the specified users.
This will allow you to have much finer control over the TTL for tokens. For example, you may want to have a short TTL for most tokens, but a specific user needs a much longer TTL (or vice versa).